### PR TITLE
Add python requirements on jsk_spot_startup

### DIFF
--- a/jsk_spot_robot/README.md
+++ b/jsk_spot_robot/README.md
@@ -8,6 +8,12 @@ jsk_spot_robot
 
 ## How to run
 
+### Install some python requirements
+
+```
+$ pip3 install -r requirements.txt
+```
+
 ### Setting up a catkin workspace for a new user in the internal pc
 
 ```

--- a/jsk_spot_robot/requirements.txt
+++ b/jsk_spot_robot/requirements.txt
@@ -1,0 +1,4 @@
+bosdyn-client
+bosdyn-mission
+bosdyn-api
+bosdyn-core

--- a/jsk_spot_robot/requirements.txt
+++ b/jsk_spot_robot/requirements.txt
@@ -1,4 +1,4 @@
-bosdyn-client
-bosdyn-mission
-bosdyn-api
-bosdyn-core
+bosdyn-client==2.0.2
+bosdyn-mission==2.0.2
+bosdyn-api==2.0.2
+bosdyn-core==2.0.2


### PR DESCRIPTION
To install `spot_ros`, I think some bosdyn packages should be installed. I added `requirements.txt` to install them.