### PR TITLE
[jsk_spot_startup] split credential to yaml file

### DIFF
--- a/jsk_spot_robot/README.md
+++ b/jsk_spot_robot/README.md
@@ -30,6 +30,14 @@ catkin build
 source $HOME/catkin_ws/devel/setup.bash
 ```
 
+After this, please modify the credential file and remove it from git tracking.
+
+```bash
+roscd jsk_spot_startup
+# modify auth/credential_config.yaml
+git update-index --skip-worktree auth/spot_credential.yaml
+```
+
 ### Bringup spot
 
 First, please turn on spot and turn on motors according to [the OPERATION section of spot user guide](https://www.bostondynamics.com/sites/default/files/inline-files/spot-user-guide.pdf)
@@ -37,7 +45,7 @@ First, please turn on spot and turn on motors according to [the OPERATION sectio
 After that, please run the ros driver and other basic programs with `jsk_spot_bringup.launch`. You can now control spot from ROS!
 
 ```bash
-roslaunch jsk_spot_startup jsk_spot_bringup.launch username:=<username> password:=<password>
+roslaunch jsk_spot_startup jsk_spot_bringup.launch
 ```
 
 This launch includes

--- a/jsk_spot_robot/jsk_spot_startup/auth/spot_credential.yaml
+++ b/jsk_spot_robot/jsk_spot_startup/auth/spot_credential.yaml
@@ -1,0 +1,3 @@
+username: "dummyusername"
+password: "dummypassword"
+hostname: "192.168.50.3"

--- a/jsk_spot_robot/jsk_spot_startup/launch/include/driver.launch
+++ b/jsk_spot_robot/jsk_spot_startup/launch/include/driver.launch
@@ -22,7 +22,7 @@
       respawn="true"
       >
     <rosparam file="$(find spot_driver)/config/spot_ros.yaml" command="load" />
-    <rosparam file="$(arg credential_config)/config/spot_credential.yaml" command="load" />
+    <rosparam file="$(arg credential_config)" command="load" />
     <remap from="joint_states" to="/joint_states"/>
     <remap from="tf" to="/tf"/>
   </node>

--- a/jsk_spot_robot/jsk_spot_startup/launch/include/driver.launch
+++ b/jsk_spot_robot/jsk_spot_startup/launch/include/driver.launch
@@ -1,7 +1,5 @@
 <launch>
-  <arg name="username" default="dummyusername" />
-  <arg name="password" default="dummypassword" />
-  <arg name="hostname" default="192.168.50.3" />
+  <arg name="credential_config" default="$(find jsk_spot_startup)/auth/spot_credential.yaml" />
 
   <param
     name="robot_description"
@@ -24,9 +22,7 @@
       respawn="true"
       >
     <rosparam file="$(find spot_driver)/config/spot_ros.yaml" command="load" />
-    <param name="username" value="$(arg username)" />
-    <param name="password" value="$(arg password)" />
-    <param name="hostname" value="$(arg hostname)" />
+    <rosparam file="$(arg credential_config)/config/spot_credential.yaml" command="load" />
     <remap from="joint_states" to="/joint_states"/>
     <remap from="tf" to="/tf"/>
   </node>

--- a/jsk_spot_robot/jsk_spot_startup/launch/jsk_spot_bringup.launch
+++ b/jsk_spot_robot/jsk_spot_startup/launch/jsk_spot_bringup.launch
@@ -1,17 +1,11 @@
 <launch>
-  <arg name="username" default="dummyusername" />
-  <arg name="password" default="dummypassword" />
-  <arg name="hostname" default="192.168.50.3" />
-
-  <arg name="pad_type" default="R1" /> <!-- Option: dualshock3, R1 -->
+  <arg name="credential_config" default="$(find jsk_spot_startup)/auth/spot_credential.yaml" />
 
   <!-- spot driver -->
   <include
       file="$(find jsk_spot_startup)/launch/include/driver.launch"
       >
-      <arg name="username" value="$(arg username)" />
-      <arg name="password" value="$(arg password)" />
-      <arg name="hostname" value="$(arg hostname)" />
+      <arg name="credential_config" value="$(arg credential_config)" />
   </include>
 
   <!-- peripheral devices -->


### PR DESCRIPTION
Split credential information from driver.launch to a credential yaml to avoid unintendetly adding credential information to git management.

In order to avoid that. please do 

```bash
roscd jsk_spot_startup
git update-index --skip-worktree auth/spot_credential.yaml
```