### PR TITLE
[jsk_spot_startup]  Fix bug about conversion from RPY Euler angle to Qauternion

### DIFF
--- a/jsk_spot_robot/spoteus/spot-interface.l
+++ b/jsk_spot_robot/spoteus/spot-interface.l
@@ -12,7 +12,7 @@
   (let (r)
     (if wait (ros::wait-for-service srvname))
     (setq r (ros::service-call srvname (instance std_srvs::TriggerRequest :init)))
-    (ros::ros-info "Call \"~A\" returns \"~A\"" srvname (send r :message))
+    (ros::ros-debug "Call \"~A\" returns \"~A\"" srvname (send r :message))
     (send r :success)))
 
 (defun call-set-bool-service (srvname data &key (wait nil))
@@ -374,9 +374,6 @@
    (let ((sin-roll  (sin (* roll  0.5))) (cos-roll  (cos (* roll  0.5)))
          (sin-pitch (sin (* pitch 0.5))) (cos-pitch (cos (* pitch 0.5)))
          (sin-yaw   (sin (* yaw   0.5))) (cos-yaw   (cos (* yaw   0.5))))
-     (print (list sin-roll cos-roll
-                  sin-pitch cos-pitch
-                  sin-yaw cos-yaw))
      (float-vector (+ (* cos-roll cos-pitch cos-yaw) (* sin-roll sin-pitch sin-yaw))
                    (- (* sin-roll cos-pitch cos-yaw) (* cos-roll sin-pitch sin-yaw))
                    (+ (* cos-roll sin-pitch cos-yaw) (* sin-roll cos-pitch sin-yaw))

--- a/jsk_spot_robot/spoteus/spot-interface.l
+++ b/jsk_spot_robot/spoteus/spot-interface.l
@@ -380,7 +380,7 @@
      (float-vector (+ (* cos-roll cos-pitch cos-yaw) (* sin-roll sin-pitch sin-yaw))
                    (- (* sin-roll cos-pitch cos-yaw) (* cos-roll sin-pitch sin-yaw))
                    (+ (* cos-roll sin-pitch cos-yaw) (* sin-roll cos-pitch sin-yaw))
-                   (- (* sin-roll cos-pitch sin-yaw) (* sin-roll sin-pitch cos-yaw)))))
+                   (- (* cos-roll cos-pitch sin-yaw) (* sin-roll sin-pitch cos-yaw)))))
   (:create-quaternion-msg-from-rpy
    (roll pitch yaw)
    (let* ((q (send self :create-quaternion-from-rpy roll pitch yaw))


### PR DESCRIPTION
@mqcmd196 

Second patch about conversion bug mentioned in https://github.com/jsk-ros-pkg/jsk_roseus/pull/662

> ros::create-quaternion-from-rpy は、返り値の順番が正しくないだけでなく、zの値の計算も正しくなかったので、使う場合は 213cc87 の変更内容も反映させてください。