### PR TITLE
do not reboot because of the infinite loop of rebooting

### DIFF
--- a/jsk_spot_robot/jsk_spot_startup/services/jsk-spot-utils-auto-power-off.service
+++ b/jsk_spot_robot/jsk_spot_startup/services/jsk-spot-utils-auto-power-off.service
@@ -3,7 +3,7 @@ Description=JSK Spot Auto Power Off Service
 
 [Service]
 Type=simple
-ExecStart=/bin/bash -c ". /opt/ros/melodic/setup.bash && . /home/spot/spot_ws/devel/setup.bash && if [ -e /var/lib/robot/config.bash ];then . /var/lib/robot/config.bash ;fi && rosrun jsk_spot_startup auto-power-off.sh && sudo reboot"
+ExecStart=/bin/bash -c ". /opt/ros/melodic/setup.bash && . /home/spot/spot_ws/devel/setup.bash && if [ -e /var/lib/robot/config.bash ];then . /var/lib/robot/config.bash ;fi && rosrun jsk_spot_startup auto-power-off.sh"
 ExecStop=/bin/kill -WINCH ${MAINPID}
 KillMode=control-group
 KillSignal=SIGTERM


### PR DESCRIPTION
The commit 29db7f4672e47f06fafe700c6866522a55e7b503 causes the infinite loop after one-shot rebooting. If you need reboot command, could you consider to add another part of the scripts? @sktometometo 