### PR TITLE
Add body inverse kinematics to control spot pose in euslisp

### DIFF
--- a/jsk_spot_robot/spoteus/spot-utils.l
+++ b/jsk_spot_robot/spoteus/spot-utils.l
@@ -48,5 +48,48 @@
           (forward-message-to front_right_knee_jt (cdr args))
           (forward-message-to rear_left_knee_jt (cdr args))
           (forward-message-to rear_right_knee_jt (cdr args)))))
+  (:body-inverse-kinematics
+    (target-coords
+     &rest args
+     &key (move-target) (link-list)
+          (min (float-vector -500 -500  -500 -200 -200 -100))
+          (max (float-vector  500  500   500  200  200  100))
+          (target-centroid-pos)
+          (rotation-axis)
+     &allow-other-keys)
+    "The purpose of this function is to use :fullbody-inverse-kinematics by only specifying body target-coords.
+Example:
+(send *spot* :body-inverse-kinematics (make-coords :pos #f(0 0 50)))
+"
+    (let ((body-coords (make-cascoords :coords (send (send self :coords) :copy-worldcoords))))
+      (send body_lk :assoc body-coords)
+      (setq target-coords
+            (list target-coords
+                  (send self :larm :end-coords :copy-worldcoords)
+                  (send self :rarm :end-coords :copy-worldcoords)
+                  (send self :lleg :end-coords :copy-worldcoords)
+                  (send self :rleg :end-coords :copy-worldcoords)))
+      (unless move-target
+        (setq move-target
+              (list body-coords
+                    (send self :larm :end-coords)
+                    (send self :rarm :end-coords)
+                    (send self :lleg :end-coords)
+                    (send self :rleg :end-coords))))
+      (unless link-list
+        (setq link-list
+              (mapcar #'(lambda (limb) (send self :link-list (send limb :parent))) move-target)))
+      (unless rotation-axis
+        (setq rotation-axis (list t nil nil nil nil)))
+      (prog1
+        (send-super*
+            :fullbody-inverse-kinematics target-coords
+            :move-target move-target
+            :link-list link-list
+            :min min
+            :max max
+            :target-centroid-pos target-centroid-pos
+            :rotation-axis rotation-axis
+            args)
+        (send body_lk :dissoc body-coords))))
   )
-


### PR DESCRIPTION
sample movie
https://user-images.githubusercontent.com/19769486/141134905-9945f8e5-5d96-4e19-9d25-b4f5e96d9592.mp4


sample code:
```
(load "package://spoteus/spot-utils.l")

(spot)
(objects (list *spot*))

(dotimes (i 100)
  (send *spot* :body-inverse-kinematics
        (make-coords :pos (float-vector 0 (* 100 (cos (* pi i 0.02))) (* 100 (sin (* pi i 0.02))))))
  (unix:usleep 20000)
  (send *irtviewer* :redraw))

(dotimes (i 100)
  (send *spot* :body-inverse-kinematics
        (make-coords :pos (float-vector 0 0 (* 20 (sin (* pi i 0.02))))
                     :rpy (float-vector (* 0.2 (sin (* pi i 0.02))) (* 0.2 (sin (* pi i 0.02))) (* 0.2 (sin (* pi i 0.02))))))
  (unix:usleep 20000)
  (send *irtviewer* :redraw))
```
