### PR TITLE
[jsk_spot_teleop] add dock teleop by dualsense

### DIFF
--- a/jsk_spot_robot/jsk_spot_teleop/config/dualsense_joystick_teleop.yaml
+++ b/jsk_spot_robot/jsk_spot_teleop/config/dualsense_joystick_teleop.yaml
@@ -10,3 +10,4 @@ button_claim: 9
 button_stair_mode: 3
 button_locomotion_mode: -1
 num_buttons: 14
+button_dock: 7

--- a/jsk_spot_robot/jsk_spot_teleop/config/dualsense_joystick_teleop.yaml
+++ b/jsk_spot_robot/jsk_spot_teleop/config/dualsense_joystick_teleop.yaml
@@ -10,5 +10,5 @@ button_claim: 9
 button_stair_mode: 3
 button_locomotion_mode: -1
 num_buttons: 14
-button_dock: 7
+axe_dock: 7
 button_enable: 4

--- a/jsk_spot_robot/jsk_spot_teleop/config/dualsense_joystick_teleop.yaml
+++ b/jsk_spot_robot/jsk_spot_teleop/config/dualsense_joystick_teleop.yaml
@@ -11,3 +11,4 @@ button_stair_mode: 3
 button_locomotion_mode: -1
 num_buttons: 14
 button_dock: 7
+button_enable: 4

--- a/jsk_spot_robot/jsk_spot_teleop/config/home_dock_id.yaml
+++ b/jsk_spot_robot/jsk_spot_teleop/config/home_dock_id.yaml
@@ -1,0 +1,2 @@
+# Need to locate /var/lib/robot/
+# dock_id: <fiducial id on docking station>

--- a/jsk_spot_robot/jsk_spot_teleop/launch/teleop.launch
+++ b/jsk_spot_robot/jsk_spot_teleop/launch/teleop.launch
@@ -31,10 +31,9 @@
         command="load"
         file="$(find jsk_spot_teleop)/config/$(arg pad_type)_teleop_twist_joy.yaml"
         />
-    <rosparam
-        command="load"
-        file="/var/lib/robot/home_dock_id.yaml"
-        />
+    <rosparam subst_value="True">
+        dock_id: $(optenv DOCKING_STATION_ID -1)
+    </rosparam>
   </node>
 
   <node

--- a/jsk_spot_robot/jsk_spot_teleop/launch/teleop.launch
+++ b/jsk_spot_robot/jsk_spot_teleop/launch/teleop.launch
@@ -31,6 +31,10 @@
         command="load"
         file="$(find jsk_spot_teleop)/config/$(arg pad_type)_teleop_twist_joy.yaml"
         />
+    <rosparam
+        command="load"
+        file="/var/lib/robot/home_dock_id.yaml"
+        />
   </node>
 
   <node

--- a/jsk_spot_robot/jsk_spot_teleop/launch/teleop.launch
+++ b/jsk_spot_robot/jsk_spot_teleop/launch/teleop.launch
@@ -31,9 +31,6 @@
         command="load"
         file="$(find jsk_spot_teleop)/config/$(arg pad_type)_teleop_twist_joy.yaml"
         />
-    <rosparam subst_value="True">
-        dock_id: $(optenv DOCKING_STATION_ID -1)
-    </rosparam>
   </node>
 
   <node
@@ -48,5 +45,8 @@
           command="load"
           file="$(find jsk_spot_teleop)/config/$(arg pad_type)_joystick_teleop.yaml"
           />
+      <rosparam subst_value="True">
+        dock_id: $(optenv DOCKING_STATION_ID -1)
+      </rosparam>
   </node>
 </launch>

--- a/jsk_spot_robot/jsk_spot_teleop/src/joystick_teleop.cpp
+++ b/jsk_spot_robot/jsk_spot_teleop/src/joystick_teleop.cpp
@@ -24,7 +24,7 @@ public:
         ros::param::param<int>("~button_claim", button_claim_, -1);
         ros::param::param<int>("~button_stair_mode", button_stair_mode_, -1);
         ros::param::param<int>("~button_locomotion_mode", button_locomotion_mode_, -1);
-	ros::param::param<int>("~axe_dock", axe_dock_, -1);
+        ros::param::param<int>("~axe_dock", axe_dock_, -1);
         ros::param::param<int>("~dock_id", dock_id_, -1);
 
         ros::param::param<int>("~num_buttons", num_buttons_, 0);
@@ -33,8 +33,8 @@ public:
         for ( auto index: pressed_ ) {
             index = false;
         }
-	ros::param::param<int>("~num_axes", num_axes_, 0);
-	num_axes_ = num_axes_ < 0 ? 0 : num_buttons_;
+        ros::param::param<int>("~num_axes", num_axes_, 0);
+        num_axes_ = num_axes_ < 0 ? 0 : num_buttons_;
         pressed_axes_.resize(num_axes_);
         for ( auto index: pressed_axes_ ) {
             index = false;
@@ -97,7 +97,7 @@ public:
                     }
                     pressed_[button_estop_hard_] = true;
                 }
-           } else {
+            } else {
                 if ( pressed_[button_estop_hard_] ) {
                     pressed_[button_estop_hard_] = false;
                 }
@@ -375,39 +375,39 @@ public:
         } else {
             ROS_DEBUG("Button 'locomotion_mode' is disabled.");
         }
-	//dock
-	if ( axe_dock_ >= 0
-	        and axe_dock_ < num_buttons_
-	        and req_dock_id_.dock_id >= 0 ){
-	    if ( msg->axes[axe_dock_]==-1 ) {
+        //dock
+        if ( axe_dock_ >= 0
+             and axe_dock_ < num_buttons_
+             and req_dock_id_.dock_id >= 0 ){
+          if ( msg->axes[axe_dock_]==-1 ) {
                 if ( not pressed_axes_[axe_dock_] ) {
-	           this->say("dock calling");
-		   spot_msgs::Dock::Response res;
-		   if (client_dock_.call(req_dock_id_, res) && res.success ){
-		     ROS_INFO("Service 'dock' succeeded.");
-		   } else {
-		     ROS_ERROR("Service 'dock' failed.");
-		   }
-		   pressed_axes_[axe_dock_] = true;
-		}
-	    } else if (msg->axes[axe_dock_]==1) {
-    	        if (not pressed_axes_[axe_dock_]){
-		  this->say("undock calling");
-		  if (client_undock_.call(srv) && srv.response.success ){
-		    ROS_INFO("Service 'undock' succeeded.");
-		  } else {
-		    ROS_ERROR("Service 'undock' failed.");
-		  }
-		  pressed_axes_[axe_dock_] = true;
-		}
-	    } else {
-	        if ( pressed_axes_[axe_dock_] ) {
-		  pressed_axes_[axe_dock_] = false;
-		}
-	    }
-	} else {
-	  ROS_DEBUG("Axe 'dock' is disabled.");
-	}
+                  this->say("dock calling");
+                  spot_msgs::Dock::Response res;
+                  if (client_dock_.call(req_dock_id_, res) && res.success ){
+                    ROS_INFO("Service 'dock' succeeded.");
+                  } else {
+                    ROS_ERROR("Service 'dock' failed.");
+                  }
+                  pressed_axes_[axe_dock_] = true;
+                }
+          } else if (msg->axes[axe_dock_]==1) {
+            if (not pressed_axes_[axe_dock_]){
+              this->say("undock calling");
+              if (client_undock_.call(srv) && srv.response.success ){
+                ROS_INFO("Service 'undock' succeeded.");
+              } else {
+                ROS_ERROR("Service 'undock' failed.");
+              }
+              pressed_axes_[axe_dock_] = true;
+            }
+          } else {
+            if ( pressed_axes_[axe_dock_] ) {
+              pressed_axes_[axe_dock_] = false;
+            }
+          }
+        } else {
+          ROS_DEBUG("Axe 'dock' is disabled.");
+        }
     }
 
 private:

--- a/jsk_spot_robot/jsk_spot_teleop/src/joystick_teleop.cpp
+++ b/jsk_spot_robot/jsk_spot_teleop/src/joystick_teleop.cpp
@@ -25,7 +25,8 @@ public:
         ros::param::param<int>("~button_stair_mode", button_stair_mode_, -1);
         ros::param::param<int>("~button_locomotion_mode", button_locomotion_mode_, -1);
         ros::param::param<int>("~button_dock", button_dock_, -1);
-        ros::param::param<int>("~dock_id", req_dock_id_.dock_id, -1);
+        ros::param::param<int>("~button_enable", button_enable_, -1);
+        ros::param::param<int>("~dock_id", dock_id_, -1);
 
         ros::param::param<int>("~num_buttons", num_buttons_, 0);
         num_buttons_ = num_buttons_ < 0 ? 0 : num_buttons_;
@@ -55,6 +56,7 @@ public:
 
         req_next_stair_mode_.data = true;
         req_next_locomotion_mode_.locomotion_mode = 4;
+        req_dock_id_.dock_id = dock_id_;
     }
 
     void say(std::string message)
@@ -373,8 +375,12 @@ public:
         if ( button_dock_ >= 0
                 and button_dock_ < msg->buttons.size()
                 and button_dock_ < num_buttons_
-                and req_dock_id_.dock_id >= 0) {
-            if ( msg->buttons[button_dock_] == 1 ) {
+                and req_dock_id_.dock_id >= 0
+                and button_enable_ >= 0
+                and button_enable_ < msg->buttons.size()
+                and button_enable_ < num_buttons_) {
+            if ( msg->buttons[button_dock_] == 1
+                     and msg->buttons[button_enable_] == 1) {
                 if ( not pressed_[button_dock_] ) {
                     this->say("dock calling");
                     spot_msgs::Dock::Response res;
@@ -409,6 +415,8 @@ private:
     int button_stair_mode_;
     int button_locomotion_mode_;
     int button_dock_;
+    int button_enable_;
+    int dock_id_;
 
     ros::ServiceClient client_estop_hard_;
     ros::ServiceClient client_estop_gentle_;

--- a/jsk_spot_robot/jsk_spot_teleop/src/joystick_teleop.cpp
+++ b/jsk_spot_robot/jsk_spot_teleop/src/joystick_teleop.cpp
@@ -25,6 +25,7 @@ public:
         ros::param::param<int>("~button_stair_mode", button_stair_mode_, -1);
         ros::param::param<int>("~button_locomotion_mode", button_locomotion_mode_, -1);
         ros::param::param<int>("~button_dock", button_dock_, -1);
+        ros::param::param<int>("~dock_id", req_dock_id_.dock_id, -1);
 
         ros::param::param<int>("~num_buttons", num_buttons_, 0);
         num_buttons_ = num_buttons_ < 0 ? 0 : num_buttons_;
@@ -54,7 +55,6 @@ public:
 
         req_next_stair_mode_.data = true;
         req_next_locomotion_mode_.locomotion_mode = 4;
-        req_dock_id_.dock_id = 520; // TODO support multiple dock_id
     }
 
     void say(std::string message)
@@ -372,7 +372,8 @@ public:
         // dock
         if ( button_dock_ >= 0
                 and button_dock_ < msg->buttons.size()
-                and button_dock_ < num_buttons_ ) {
+                and button_dock_ < num_buttons_
+                and req_dock_id_.dock_id >= 0) {
             if ( msg->buttons[button_dock_] == 1 ) {
                 if ( not pressed_[button_dock_] ) {
                     this->say("dock calling");

--- a/jsk_spot_robot/jsk_spot_teleop/src/joystick_teleop.cpp
+++ b/jsk_spot_robot/jsk_spot_teleop/src/joystick_teleop.cpp
@@ -390,7 +390,7 @@ public:
                  }
             }
         } else {
-            ROS_DEBUG("Axe 'dock' is disabled.");
+            ROS_DEBUG("Button 'dock' is disabled.");
         }
     }
 


### PR DESCRIPTION
This PR supports spot docking by dualsense.
~~R2 is assigned as the docking button, but this button is prone to being accidentally pressed (e.g. when placed on a desk.)~~
This script supports only for Strelka currently. I don't know how Belka will behave.

**TODO**

- [x] Support for multiple robot/Dock ID to make it safe for robots that do not have a dock acceptance mechanism
- [x] ~~Docking by pressing the two buttons simultaneously to avoid malfunction~~
- [x] Use axes (cross key)