### PR TITLE
[spoteus] Add docstring to spot-interface.l

### DIFF
--- a/jsk_spot_robot/spoteus/spot-interface.l
+++ b/jsk_spot_robot/spoteus/spot-interface.l
@@ -328,6 +328,15 @@
   (:body-pose
    ;; pose expected to get 3 elements float-vector (r p y), or eus coords.
     (pose &key (topic-name "/spot/body_pose"))
+    "
+    Set spot body pose
+    Args:
+      pose: (float-vector r p y) or (list rpy) or eus coords
+    Examples:
+      (send self :body-pose #f(0 0.2 0))
+      (send self :body-pose (list 0 0.2 0))
+      (send self :body-pose (send *robot* :copy-worldcoords))
+    "
     (when (send self :simulation-modep)
       (return-from :body-pose t))
     (unless (ros::get-topic-publisher topic-name)

--- a/jsk_spot_robot/spoteus/spot-interface.l
+++ b/jsk_spot_robot/spoteus/spot-interface.l
@@ -338,6 +338,7 @@
       (send self :body-pose #f(0 0.2 0))
       (send self :body-pose (list 0 0.2 0))
       (send self :body-pose (send *robot* :copy-worldcoords))
+      (send self :body-pose (make-coords)) ;; return to default pose
     "
     (when (send self :simulation-modep)
       (return-from :body-pose t))

--- a/jsk_spot_robot/spoteus/spot-interface.l
+++ b/jsk_spot_robot/spoteus/spot-interface.l
@@ -332,6 +332,8 @@
     Set spot body pose
     Args:
       pose: (float-vector r p y) or (list rpy) or eus coords
+      - key
+        topic-name: Set the topic name to publish (default \"/spot/body_pose\")
     Examples:
       (send self :body-pose #f(0 0.2 0))
       (send self :body-pose (list 0 0.2 0))

--- a/jsk_spot_robot/spoteus/spot-interface.l
+++ b/jsk_spot_robot/spoteus/spot-interface.l
@@ -318,6 +318,7 @@
         nil)
       ))
   (:get-current-spot ()
+    "get current node id "
     (let (msg)
       (setq msg (one-shot-subscribe "/spot_behavior_manager_server/current_node_id" std_msgs::String :timeout 5000))
       (if (not msg)

--- a/jsk_spot_robot/spoteus/spot-interface.l
+++ b/jsk_spot_robot/spoteus/spot-interface.l
@@ -230,7 +230,13 @@
   (:set-locomotion-mode (locomotion-hint) "Set locomotion mode" (call-set-locomotion-service "/spot/locomotion_mode" locomotion-hint))
   (:set-stair-mode (is-stair-mode) "Set stair mode" (call-set-bool-service "/spot/stair_mode" is-stair-mode))
   ;;
-  (:dock (dock-id) "Dock the robot" (call-dock-service "/spot/dock" dock-id))
+  (:dock (dock-id)
+    "
+    Dock the robot
+    Args:
+      dock-id: dock fiducial id
+    "
+    (call-dock-service "/spot/dock" dock-id))
   (:undock
    ()
    "Undock the robot"


### PR DESCRIPTION
As the number of Spot users has been increasing lately, I think it is necessary to maintain the documentation. As one of the efforts, I thought it would be a good idea to add docstrings to the methods described in spot-interface.l. (Of cource, I also think we should  update something like spot-interaction made by google slide)

I wrote this without thinking so much about what style would be best.
I'd be happy to hear your thoughts on the style of the docstrings in your spare time.