### PR TITLE
Erase double and strange explanation in README.md

### DIFF
--- a/jsk_kinova_robot/README.md
+++ b/jsk_kinova_robot/README.md
@@ -145,10 +145,6 @@ To control real robot. you can use *ri* object.
 ```
 2000 indicates we ask robot to move for 2000 [msec]
 
-To obtain current robot pose, use :state :potentio-vector method.
-```
-(send *kinova* :arm :move-end-pos #f(0 0 -50))
-```
 
 To obtain current robot pose, use `:state :potentio-vector` method.
 


### PR DESCRIPTION
Erase the following script because it is double and the explanation does not match the code .

To obtain current robot pose, use :state :potentio-vector method.
```
(send *kinova* :arm :move-end-pos #f(0 0 -50))
```