### PR TITLE
[jsk_spot_startup] update config script

### DIFF
--- a/jsk_spot_robot/jsk_spot_startup/config/bash/bashrc
+++ b/jsk_spot_robot/jsk_spot_startup/config/bash/bashrc
@@ -116,6 +116,4 @@ if ! shopt -oq posix; then
   fi
 fi
 
-source /opt/ros/melodic/setup.bash
 source ~/spot_ws/devel/setup.bash
-source /var/lib/robot/config.bash

--- a/jsk_spot_robot/jsk_spot_startup/config/bash/config.bash
+++ b/jsk_spot_robot/jsk_spot_startup/config/bash/config.bash
@@ -8,8 +8,9 @@ export IF_LTE="noltedevice"
 
 # ROS_IP and ROS_MASTER_URI
 WIFI_AP_IP=10.42.0.1
-rossetmaster $WIFI_AP_IP
-rossetip $WIFI_AP_IP
+export ROS_MASTER_URI=http://$WIFI_AP_IP:11311/
+export ROS_IP=$WIFI_AP_IP
+export ROS_HOSTNAME=$WIFI_AP_IP
 
 # Robot Name
 # export ROBOT_NAME=

--- a/jsk_spot_robot/jsk_spot_startup/config/bash/jsk_profile.sh
+++ b/jsk_spot_robot/jsk_spot_startup/config/bash/jsk_profile.sh
@@ -1,3 +1,6 @@
+# This file must be put at /etc/profile.d/jsk.sh
+# And loaded at first.
+
 if [ -e /var/lib/robot/config.bash ]; then
     source /var/lib/robot/config.bash
 else


### PR DESCRIPTION
以下の2つのPRを受けて bashの設定周りのファイルの修正

- https://github.com/sktometometo/jsk_robot/pull/139/files
- https://github.com/sktometometo/jsk_robot/pull/145

今まで rossetip/rossetmaster をするために config.bash の内部で/opt/ros/melodic/setup.bash をsourceしていたが、直にROS_MASTER_URIとROS_IP/ROS_HOSTNAMEを設定することでsourceしなくていいようにした.
(ROSの環境変数については[このぺーじ](http://wiki.ros.org/ja/ROS/EnvironmentVariables)を参照)

結果, config.bash をsourceするタイミングは自由になった.

今は以下のようなsource順になっている.

## systemd Unit

- setup.bash のload
- config.bash のload

## 各ユーザーのbash

- jsk.shのload(内部でconfig.bashのload)
- $HOME/.bashrcのload (記載があればsetup.bashのload)