### PR TITLE
[spot_autowalk_data] skip edge that does not have snapshot ID

### DIFF
--- a/jsk_spot_robot/spot_autowalk_data/scripts/view_map.py
+++ b/jsk_spot_robot/spot_autowalk_data/scripts/view_map.py
@@ -254,6 +254,10 @@ def load_map(path):
                 current_waypoint_snapshots[waypoint_snapshot.id] = waypoint_snapshot
         # Similarly, edges have snapshot data.
         for edge in current_graph.edges:
+
+            if not edge.snapshot_id:
+                continue # Rare case that snapshot id is empty
+
             file_name = os.path.join(path, "edge_snapshots", edge.snapshot_id)
             if not os.path.exists(file_name):
                 continue


### PR DESCRIPTION
### What is this

A patch to solve a rare case in visualizing the autowalk map.
Skip processing the edge that has no valid snapshot id.

Please try this with https://drive.google.com/drive/folders/1NzGVwUpJkPIc7-859u3CUZHC6VnBoPYL?usp=sharing 